### PR TITLE
Fixes SwiftLint warning

### DIFF
--- a/Base VIPER Interfaces V2/BaseWireframe.swift
+++ b/Base VIPER Interfaces V2/BaseWireframe.swift
@@ -36,7 +36,7 @@ extension BaseWireframe {
 
 extension UIViewController {
     
-    func presentWireframe(_ wireframe: BaseWireframe, animated: Bool = true, completion: (()->())? = nil) {
+    func presentWireframe(_ wireframe: BaseWireframe, animated: Bool = true, completion: (() -> Void)? = nil) {
         present(wireframe.viewController, animated: animated, completion: completion)
     }
     

--- a/Demo/Viper-v2-Demo/Common/VIPER/BaseWireframe.swift
+++ b/Demo/Viper-v2-Demo/Common/VIPER/BaseWireframe.swift
@@ -65,7 +65,7 @@ extension BaseWireframe {
 
 extension UIViewController {
     
-    func presentWireframe(_ wireframe: BaseWireframe, animated: Bool = true, completion: (()->())? = nil) {
+    func presentWireframe(_ wireframe: BaseWireframe, animated: Bool = true, completion: (() -> Void)? = nil) {
         present(wireframe.viewController, animated: animated, completion: completion)
     }
     


### PR DESCRIPTION
SwiftLint said following message.

```
Void Return Violation: Prefer `-> Void` over `-> ()`. (void_return)
```
https://github.com/realm/SwiftLint/blob/master/Rules.md#void-return