### PR TITLE
Version 3.1 - Replace class with AnyObject

### DIFF
--- a/Base VIPER Interfaces/BaseWireframe.swift
+++ b/Base VIPER Interfaces/BaseWireframe.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol WireframeInterface: class {
+protocol WireframeInterface: AnyObject {
 }
 
 class BaseWireframe {

--- a/Base VIPER Interfaces/FormatterInterface.swift
+++ b/Base VIPER Interfaces/FormatterInterface.swift
@@ -1,4 +1,4 @@
-protocol FormatterInterface: class {
+protocol FormatterInterface: AnyObject {
 }
 
 extension FormatterInterface {

--- a/Base VIPER Interfaces/InteractorInterface.swift
+++ b/Base VIPER Interfaces/InteractorInterface.swift
@@ -1,4 +1,4 @@
-protocol InteractorInterface: class {
+protocol InteractorInterface: AnyObject {
 }
 
 extension InteractorInterface {

--- a/Base VIPER Interfaces/PresenterInterface.swift
+++ b/Base VIPER Interfaces/PresenterInterface.swift
@@ -1,4 +1,4 @@
-protocol PresenterInterface: class {
+protocol PresenterInterface: AnyObject {
 }
 
 extension PresenterInterface {

--- a/Base VIPER Interfaces/ViewInterface.swift
+++ b/Base VIPER Interfaces/ViewInterface.swift
@@ -1,4 +1,4 @@
-protocol ViewInterface: class {
+protocol ViewInterface: AnyObject {
 }
 
 extension ViewInterface {

--- a/Demo/Viper-v2-Demo/Application/Initializers/Initializer.swift
+++ b/Demo/Viper-v2-Demo/Application/Initializers/Initializer.swift
@@ -8,6 +8,6 @@
 
 import Foundation
 
-protocol Initializable: class {
+protocol Initializable: AnyObject {
     func performInitialization()
 }

--- a/Demo/Viper-v2-Demo/Common/VIPER/BaseWireframe.swift
+++ b/Demo/Viper-v2-Demo/Common/VIPER/BaseWireframe.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SafariServices
 
-protocol WireframeInterface: class {
+protocol WireframeInterface: AnyObject {
     func popFromNavigationController(animated: Bool)
     func dismiss(animated: Bool)
 

--- a/Demo/Viper-v2-Demo/Common/VIPER/InteractorInterface.swift
+++ b/Demo/Viper-v2-Demo/Common/VIPER/InteractorInterface.swift
@@ -1,4 +1,4 @@
-protocol InteractorInterface: class {
+protocol InteractorInterface: AnyObject {
 }
 
 extension InteractorInterface {

--- a/Demo/Viper-v2-Demo/Common/VIPER/PresenterInterface.swift
+++ b/Demo/Viper-v2-Demo/Common/VIPER/PresenterInterface.swift
@@ -1,4 +1,4 @@
-protocol PresenterInterface: class {
+protocol PresenterInterface: AnyObject {
     func viewDidLoad()
     func viewWillAppear(animated: Bool)
     func viewDidAppear(animated: Bool)

--- a/Demo/Viper-v2-Demo/Common/VIPER/ViewInterface.swift
+++ b/Demo/Viper-v2-Demo/Common/VIPER/ViewInterface.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SVProgressHUD
 
-protocol ViewInterface: class {
+protocol ViewInterface: AnyObject {
     func showProgressHUD()
     func hideProgressHUD()
 }


### PR DESCRIPTION
Replaced class with AnyObject since class is deprecated and using it results in warnings when using Xcode 12.5.