### PR TITLE
Fix warnings generated by swiftlint

### DIFF
--- a/Base VIPER Interfaces/BaseWireframe.swift
+++ b/Base VIPER Interfaces/BaseWireframe.swift
@@ -6,8 +6,8 @@ protocol WireframeInterface: AnyObject {
 class BaseWireframe<ViewController> where ViewController: UIViewController {
 
     private unowned var _viewController: ViewController
-    
-    //to retain view controller reference upon first access
+
+    // to retain view controller reference upon first access
     private var temporaryStoredViewController: ViewController?
 
     init(viewController: ViewController) {
@@ -22,7 +22,7 @@ extension BaseWireframe: WireframeInterface {
 }
 
 extension BaseWireframe {
-    
+
     var viewController: ViewController {
         defer { temporaryStoredViewController = nil }
         return _viewController
@@ -35,7 +35,7 @@ extension BaseWireframe {
 }
 
 extension UIViewController {
-    
+
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
         present(wireframe.viewController, animated: animated, completion: completion)
     }
@@ -43,11 +43,11 @@ extension UIViewController {
 }
 
 extension UINavigationController {
-    
+
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
         self.pushViewController(wireframe.viewController, animated: animated)
     }
-    
+
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
         self.setViewControllers([wireframe.viewController], animated: animated)
     }

--- a/Base VIPER Interfaces/UIStoryboardExtension.swift
+++ b/Base VIPER Interfaces/UIStoryboardExtension.swift
@@ -4,6 +4,8 @@ extension UIStoryboard {
 
     func instantiateViewController<T: UIViewController>(ofType _: T.Type, withIdentifier identifier: String? = nil) -> T {
         let identifier = identifier ?? String(describing: T.self)
+
+        // swiftlint:disable:next force_cast
         return instantiateViewController(withIdentifier: identifier) as! T
     }
 


### PR DESCRIPTION
When using suggested swiflint configuration at:
https://infinum.com/handbook/resources/ios/swiftlint.yml
swiftlint reports warnings for:
- force cast
- trailing whitespace
- missing space in comment