### PR TITLE
Refactor BaseWireframe (change `viewController` property to `getDeallocatableViewController` method)

### DIFF
--- a/Base VIPER Interfaces/BaseWireframe.swift
+++ b/Base VIPER Interfaces/BaseWireframe.swift
@@ -23,31 +23,29 @@ extension BaseWireframe: WireframeInterface {
 
 extension BaseWireframe {
 
-    /// > Warning: The reference to the `ViewController` that the method returns
-    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
-    func getDeallocatableViewController() -> ViewController {
+    var viewController: ViewController {
         defer { temporaryStoredViewController = nil }
-        guard let viewController = _viewController else {
+        guard let vc = _viewController else {
             fatalError(
             """
             The `ViewController` instance that the `_viewController` property holds
-            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+            was already deallocated in a previous access to the `viewController` computed property.
 
             If you don't store the `ViewController` instance as a strong reference
-            at the call site of the `getDeallocatableViewController` method,
+            at the call site of the `viewController` computed property,
             there is no guarantee that the `ViewController` instance won't be deallocated since the
             `_viewController` property has a weak reference to the `ViewController` instance.
 
-            For the correct usage of this method, make sure to keep a strong reference
-            to the `ViewController` instance that the method returns.
+            For the correct usage of this computed property, make sure to keep a strong reference
+            to the `ViewController` instance that it returns.
             """
             )
         }
-        return viewController
+        return vc
     }
 
     var navigationController: UINavigationController? {
-        return getDeallocatableViewController().navigationController
+        return viewController.navigationController
     }
 
 }
@@ -55,7 +53,7 @@ extension BaseWireframe {
 extension UIViewController {
 
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
+        present(wireframe.viewController, animated: animated, completion: completion)
     }
 
 }
@@ -63,11 +61,11 @@ extension UIViewController {
 extension UINavigationController {
 
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
+        pushViewController(wireframe.viewController, animated: animated)
     }
 
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
+        setViewControllers([wireframe.viewController], animated: animated)
     }
 
 }

--- a/Base VIPER Interfaces/BaseWireframe.swift
+++ b/Base VIPER Interfaces/BaseWireframe.swift
@@ -5,9 +5,9 @@ protocol WireframeInterface: AnyObject {
 
 class BaseWireframe<ViewController> where ViewController: UIViewController {
 
-    private unowned var _viewController: ViewController
+    private weak var _viewController: ViewController?
 
-    // We need it in order to retain view controller reference upon first access
+    // We need it in order to retain the view controller reference upon first access
     private var temporaryStoredViewController: ViewController?
 
     init(viewController: ViewController) {
@@ -23,13 +23,31 @@ extension BaseWireframe: WireframeInterface {
 
 extension BaseWireframe {
 
-    var viewController: ViewController {
+    /// > Warning: The reference to the `ViewController` that the method returns
+    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
+    func getDeallocatableViewController() -> ViewController {
         defer { temporaryStoredViewController = nil }
-        return _viewController
+        guard let viewController = _viewController else {
+            fatalError(
+            """
+            The `ViewController` instance that the `_viewController` property holds
+            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+
+            If you don't store the `ViewController` instance as a strong reference
+            at the call site of the `getDeallocatableViewController` method,
+            there is no guarantee that the `ViewController` instance won't be deallocated since the
+            `_viewController` property has a weak reference to the `ViewController` instance.
+
+            For the correct usage of this method, make sure to keep a strong reference
+            to the `ViewController` instance that the method returns.
+            """
+            )
+        }
+        return viewController
     }
 
     var navigationController: UINavigationController? {
-        return viewController.navigationController
+        return getDeallocatableViewController().navigationController
     }
 
 }
@@ -37,7 +55,7 @@ extension BaseWireframe {
 extension UIViewController {
 
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.viewController, animated: animated, completion: completion)
+        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
     }
 
 }
@@ -45,11 +63,11 @@ extension UIViewController {
 extension UINavigationController {
 
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.viewController, animated: animated)
+        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
     }
 
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.viewController], animated: animated)
+        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
     }
 
 }

--- a/Demo/Viper-Demo/Viper-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Viper-Demo/Viper-Demo.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		376894F4270C38240094A3C2 /* SFProDisplay-Regular.OTF in Resources */ = {isa = PBXBuildFile; fileRef = 376894F0270C38240094A3C2 /* SFProDisplay-Regular.OTF */; };
 		376894F5270C38240094A3C2 /* SFProText-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 376894F1270C38240094A3C2 /* SFProText-Regular.ttf */; };
 		376894F6270C38240094A3C2 /* SFProDisplay-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 376894F2270C38240094A3C2 /* SFProDisplay-Semibold.ttf */; };
-		37689501270C3A0F0094A3C2 /* BaseWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376894FB270C3A0F0094A3C2 /* BaseWireframe.swift */; };
 		37689502270C3A0F0094A3C2 /* FormatterInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376894FC270C3A0F0094A3C2 /* FormatterInterface.swift */; };
 		37689503270C3A0F0094A3C2 /* UIStoryboardExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376894FD270C3A0F0094A3C2 /* UIStoryboardExtension.swift */; };
 		37689504270C3A0F0094A3C2 /* PresenterInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376894FE270C3A0F0094A3C2 /* PresenterInterface.swift */; };
@@ -75,6 +74,7 @@
 		37976911270DA07A003F244A /* HomeWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797690B270DA07A003F244A /* HomeWireframe.swift */; };
 		3797691E270DA772003F244A /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797691D270DA772003F244A /* Show.swift */; };
 		37976920270DB761003F244A /* ShowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3797691F270DB761003F244A /* ShowService.swift */; };
+		5C3BD0572948854100DB7DB9 /* BaseWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3BD0562948854100DB7DB9 /* BaseWireframe.swift */; };
 		BE04F055E2D63DE290D80E0A /* Pods_Viper_DemoTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDD53CE7F757DDD0CBC45097 /* Pods_Viper_DemoTests.framework */; };
 		BEA6D1FF4D362F748926CE78 /* Pods_Viper_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 582FC52112AD9E8263172E25 /* Pods_Viper_Demo.framework */; };
 /* End PBXBuildFile section */
@@ -117,7 +117,6 @@
 		376894F0270C38240094A3C2 /* SFProDisplay-Regular.OTF */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProDisplay-Regular.OTF"; sourceTree = "<group>"; };
 		376894F1270C38240094A3C2 /* SFProText-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Regular.ttf"; sourceTree = "<group>"; };
 		376894F2270C38240094A3C2 /* SFProDisplay-Semibold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProDisplay-Semibold.ttf"; sourceTree = "<group>"; };
-		376894FB270C3A0F0094A3C2 /* BaseWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseWireframe.swift; sourceTree = "<group>"; };
 		376894FC270C3A0F0094A3C2 /* FormatterInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatterInterface.swift; sourceTree = "<group>"; };
 		376894FD270C3A0F0094A3C2 /* UIStoryboardExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtension.swift; sourceTree = "<group>"; };
 		376894FE270C3A0F0094A3C2 /* PresenterInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresenterInterface.swift; sourceTree = "<group>"; };
@@ -174,6 +173,7 @@
 		3797691D270DA772003F244A /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
 		3797691F270DB761003F244A /* ShowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowService.swift; sourceTree = "<group>"; };
 		582FC52112AD9E8263172E25 /* Pods_Viper_Demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Viper_Demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C3BD0562948854100DB7DB9 /* BaseWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseWireframe.swift; sourceTree = "<group>"; };
 		980F8C1AD8CCA88BFCBF230B /* Pods_Viper_Demo_Viper_DemoUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Viper_Demo_Viper_DemoUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDD53CE7F757DDD0CBC45097 /* Pods_Viper_DemoTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Viper_DemoTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF6963554B139A9531B49E47 /* Pods-Viper-Demo-Viper-DemoUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Viper-Demo-Viper-DemoUITests.release.xcconfig"; path = "Target Support Files/Pods-Viper-Demo-Viper-DemoUITests/Pods-Viper-Demo-Viper-DemoUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -312,7 +312,7 @@
 		376894FA270C3A030094A3C2 /* VIPER */ = {
 			isa = PBXGroup;
 			children = (
-				376894FB270C3A0F0094A3C2 /* BaseWireframe.swift */,
+				5C3BD0562948854100DB7DB9 /* BaseWireframe.swift */,
 				376894FC270C3A0F0094A3C2 /* FormatterInterface.swift */,
 				376894FD270C3A0F0094A3C2 /* UIStoryboardExtension.swift */,
 				376894FE270C3A0F0094A3C2 /* PresenterInterface.swift */,
@@ -784,7 +784,6 @@
 				37689502270C3A0F0094A3C2 /* FormatterInterface.swift in Sources */,
 				3784CB79270ED5F5001643A0 /* HomeTableViewCell.swift in Sources */,
 				3785C8C2270F0B0800BDE417 /* TableCellItem.swift in Sources */,
-				37689501270C3A0F0094A3C2 /* BaseWireframe.swift in Sources */,
 				3785C8D1270F1C0600BDE417 /* ShowDetailsResponse.swift in Sources */,
 				3785C8A6270F068100BDE417 /* ShowDetailsPresenter.swift in Sources */,
 				37976910270DA07A003F244A /* HomeInteractor.swift in Sources */,
@@ -795,6 +794,7 @@
 				3785C8AF270F080700BDE417 /* ShowDescriptionTableViewCell.swift in Sources */,
 				3784CB7C270ED678001643A0 /* UITableView+Dequeue.swift in Sources */,
 				3785C8B5270F084F00BDE417 /* NoReviewTableViewCell.swift in Sources */,
+				5C3BD0572948854100DB7DB9 /* BaseWireframe.swift in Sources */,
 				3785C8BA270F0A5400BDE417 /* Review.swift in Sources */,
 				3785C8B3270F083300BDE417 /* ReviewTableViewCell.swift in Sources */,
 				3768952E270C772E0094A3C2 /* EmailValidator.swift in Sources */,

--- a/Demo/Viper-Demo/Viper-Demo/Common/VIPER/BaseWireframe.swift
+++ b/Demo/Viper-Demo/Viper-Demo/Common/VIPER/BaseWireframe.swift
@@ -35,31 +35,29 @@ extension BaseWireframe: WireframeInterface {
 
 extension BaseWireframe {
 
-    /// > Warning: The reference to the `ViewController` that the method returns
-    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
-    func getDeallocatableViewController() -> ViewController {
+    var viewController: ViewController {
         defer { temporaryStoredViewController = nil }
-        guard let viewController = _viewController else {
+        guard let vc = _viewController else {
             fatalError(
             """
             The `ViewController` instance that the `_viewController` property holds
-            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+            was already deallocated in a previous access to the `viewController` computed property.
 
             If you don't store the `ViewController` instance as a strong reference
-            at the call site of the `getDeallocatableViewController` method,
+            at the call site of the `viewController` computed property,
             there is no guarantee that the `ViewController` instance won't be deallocated since the
             `_viewController` property has a weak reference to the `ViewController` instance.
 
-            For the correct usage of this method, make sure to keep a strong reference
-            to the `ViewController` instance that the method returns.
+            For the correct usage of this computed property, make sure to keep a strong reference
+            to the `ViewController` instance that it returns.
             """
             )
         }
-        return viewController
+        return vc
     }
 
     var navigationController: UINavigationController? {
-        return getDeallocatableViewController().navigationController
+        return viewController.navigationController
     }
 
 }
@@ -67,7 +65,7 @@ extension BaseWireframe {
 extension UIViewController {
 
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
+        present(wireframe.viewController, animated: animated, completion: completion)
     }
 
 }
@@ -75,11 +73,11 @@ extension UIViewController {
 extension UINavigationController {
 
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
+        pushViewController(wireframe.viewController, animated: animated)
     }
 
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
+        setViewControllers([wireframe.viewController], animated: animated)
     }
 
 }

--- a/Demo/Viper-Demo/Viper-Demo/Common/VIPER/BaseWireframe.swift
+++ b/Demo/Viper-Demo/Viper-Demo/Common/VIPER/BaseWireframe.swift
@@ -6,8 +6,8 @@ protocol WireframeInterface: AnyObject {
 
 class BaseWireframe<ViewController> where ViewController: UIViewController {
 
-    private unowned var _viewController: ViewController
-    
+    private weak var _viewController: ViewController?
+
     // We need it in order to retain the view controller reference upon first access
     private var temporaryStoredViewController: ViewController?
 
@@ -19,6 +19,7 @@ class BaseWireframe<ViewController> where ViewController: UIViewController {
 }
 
 extension BaseWireframe: WireframeInterface {
+
     func showAlert(with title: String?, message: String?) {
         let okAction = UIAlertAction(title: "OK", style: .default, handler: nil)
         showAlert(with: title, message: message, actions: [okAction])
@@ -29,37 +30,56 @@ extension BaseWireframe: WireframeInterface {
         actions.forEach { alert.addAction($0) }
         navigationController?.present(alert, animated: true, completion: nil)
     }
+
 }
 
 extension BaseWireframe {
-    
-    var viewController: ViewController {
+
+    /// > Warning: The reference to the `ViewController` that the method returns
+    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
+    func getDeallocatableViewController() -> ViewController {
         defer { temporaryStoredViewController = nil }
-        return _viewController
+        guard let viewController = _viewController else {
+            fatalError(
+            """
+            The `ViewController` instance that the `_viewController` property holds
+            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+
+            If you don't store the `ViewController` instance as a strong reference
+            at the call site of the `getDeallocatableViewController` method,
+            there is no guarantee that the `ViewController` instance won't be deallocated since the
+            `_viewController` property has a weak reference to the `ViewController` instance.
+
+            For the correct usage of this method, make sure to keep a strong reference
+            to the `ViewController` instance that the method returns.
+            """
+            )
+        }
+        return viewController
     }
 
     var navigationController: UINavigationController? {
-        return viewController.navigationController
+        return getDeallocatableViewController().navigationController
     }
 
 }
 
 extension UIViewController {
-    
+
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.viewController, animated: animated, completion: completion)
+        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
     }
 
 }
 
 extension UINavigationController {
-    
+
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.viewController, animated: animated)
+        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
     }
-    
+
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.viewController], animated: animated)
+        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -126,31 +126,29 @@ extension BaseWireframe: WireframeInterface {
 
 extension BaseWireframe {
 
-    /// > Warning: The reference to the `ViewController` that the method returns
-    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
-    func getDeallocatableViewController() -> ViewController {
+    var viewController: ViewController {
         defer { temporaryStoredViewController = nil }
-        guard let viewController = _viewController else {
+        guard let vc = _viewController else {
             fatalError(
             """
             The `ViewController` instance that the `_viewController` property holds
-            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+            was already deallocated in a previous access to the `viewController` computed property.
 
             If you don't store the `ViewController` instance as a strong reference
-            at the call site of the `getDeallocatableViewController` method,
+            at the call site of the `viewController` computed property,
             there is no guarantee that the `ViewController` instance won't be deallocated since the
             `_viewController` property has a weak reference to the `ViewController` instance.
 
-            For the correct usage of this method, make sure to keep a strong reference
-            to the `ViewController` instance that the method returns.
+            For the correct usage of this computed property, make sure to keep a strong reference
+            to the `ViewController` instance that it returns.
             """
             )
         }
-        return viewController
+        return vc
     }
 
     var navigationController: UINavigationController? {
-        return getDeallocatableViewController().navigationController
+        return viewController.navigationController
     }
 
 }
@@ -158,7 +156,7 @@ extension BaseWireframe {
 extension UIViewController {
 
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
+        present(wireframe.viewController, animated: animated, completion: completion)
     }
 
 }
@@ -166,11 +164,11 @@ extension UIViewController {
 extension UINavigationController {
 
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
+        pushViewController(wireframe.viewController, animated: animated)
     }
 
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
+        setViewControllers([wireframe.viewController], animated: animated)
     }
 
 }

--- a/Templates/VIPER Templates/Base.xctemplate/BaseWireframe.swift
+++ b/Templates/VIPER Templates/Base.xctemplate/BaseWireframe.swift
@@ -23,31 +23,29 @@ extension BaseWireframe: WireframeInterface {
 
 extension BaseWireframe {
 
-    /// > Warning: The reference to the `ViewController` that the method returns
-    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
-    func getDeallocatableViewController() -> ViewController {
+    var viewController: ViewController {
         defer { temporaryStoredViewController = nil }
-        guard let viewController = _viewController else {
+        guard let vc = _viewController else {
             fatalError(
             """
             The `ViewController` instance that the `_viewController` property holds
-            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+            was already deallocated in a previous access to the `viewController` computed property.
 
             If you don't store the `ViewController` instance as a strong reference
-            at the call site of the `getDeallocatableViewController` method,
+            at the call site of the `viewController` computed property,
             there is no guarantee that the `ViewController` instance won't be deallocated since the
             `_viewController` property has a weak reference to the `ViewController` instance.
 
-            For the correct usage of this method, make sure to keep a strong reference
-            to the `ViewController` instance that the method returns.
+            For the correct usage of this computed property, make sure to keep a strong reference
+            to the `ViewController` instance that it returns.
             """
             )
         }
-        return viewController
+        return vc
     }
 
     var navigationController: UINavigationController? {
-        return getDeallocatableViewController().navigationController
+        return viewController.navigationController
     }
 
 }
@@ -55,7 +53,7 @@ extension BaseWireframe {
 extension UIViewController {
 
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
+        present(wireframe.viewController, animated: animated, completion: completion)
     }
 
 }
@@ -63,11 +61,11 @@ extension UIViewController {
 extension UINavigationController {
 
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
+        pushViewController(wireframe.viewController, animated: animated)
     }
 
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
+        setViewControllers([wireframe.viewController], animated: animated)
     }
 
 }

--- a/Templates/VIPER Templates/Base.xctemplate/BaseWireframe.swift
+++ b/Templates/VIPER Templates/Base.xctemplate/BaseWireframe.swift
@@ -5,8 +5,8 @@ protocol WireframeInterface: AnyObject {
 
 class BaseWireframe<ViewController> where ViewController: UIViewController {
 
-    private unowned var _viewController: ViewController
-    
+    private weak var _viewController: ViewController?
+
     // We need it in order to retain the view controller reference upon first access
     private var temporaryStoredViewController: ViewController?
 
@@ -22,34 +22,52 @@ extension BaseWireframe: WireframeInterface {
 }
 
 extension BaseWireframe {
-    
-    var viewController: ViewController {
+
+    /// > Warning: The reference to the `ViewController` that the method returns
+    /// > needs to be kept strongly at the call site of the method in order for it to not be deallocated.
+    func getDeallocatableViewController() -> ViewController {
         defer { temporaryStoredViewController = nil }
-        return _viewController
+        guard let viewController = _viewController else {
+            fatalError(
+            """
+            The `ViewController` instance that the `_viewController` property holds
+            was already deallocated in a previous call to the `getDeallocatableViewController` method.
+
+            If you don't store the `ViewController` instance as a strong reference
+            at the call site of the `getDeallocatableViewController` method,
+            there is no guarantee that the `ViewController` instance won't be deallocated since the
+            `_viewController` property has a weak reference to the `ViewController` instance.
+
+            For the correct usage of this method, make sure to keep a strong reference
+            to the `ViewController` instance that the method returns.
+            """
+            )
+        }
+        return viewController
     }
 
     var navigationController: UINavigationController? {
-        return viewController.navigationController
+        return getDeallocatableViewController().navigationController
     }
 
 }
 
 extension UIViewController {
-    
+
     func presentWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true, completion: (() -> Void)? = nil) {
-        present(wireframe.viewController, animated: animated, completion: completion)
+        present(wireframe.getDeallocatableViewController(), animated: animated, completion: completion)
     }
 
 }
 
 extension UINavigationController {
-    
+
     func pushWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        pushViewController(wireframe.viewController, animated: animated)
+        pushViewController(wireframe.getDeallocatableViewController(), animated: animated)
     }
-    
+
     func setRootWireframe<ViewController>(_ wireframe: BaseWireframe<ViewController>, animated: Bool = true) {
-        setViewControllers([wireframe.viewController], animated: animated)
+        setViewControllers([wireframe.getDeallocatableViewController()], animated: animated)
     }
 
 }


### PR DESCRIPTION
This pr has changed the `BaseWireframe` implementation. Since the old implementation, which had the `viewController` property, introduced issues on multiple projects which were hard to debug, we decided to implement a solution that would be easier to debug and less error-prone. 

The `viewController` property is replaced with the `getDeallocatableViewController` method which suggests that the `viewController` instance will be deallocated if the caller doesn't hold a strong reference to it at the call site. Also, we introduced a fatalError to the `getDeallocatableViewController` method in order to provide a better error description if the user of the method doesn't use the method as it was intended.